### PR TITLE
Bugfix: 'materialized' argument is required

### DIFF
--- a/lib/scenic/adapters/mysql/views.rb
+++ b/lib/scenic/adapters/mysql/views.rb
@@ -40,7 +40,8 @@ module Scenic
 
           Scenic::View.new(
             name: table_name,
-            definition: scrub_view_def(view_def)
+            definition: scrub_view_def(view_def),
+            materialized: false
           )
         end
 


### PR DESCRIPTION
After creating a view and invoking `bundle exec rake db:migrate` thing would break with the following stack trace:

```bash
my_project $ ber db:migrate --trace
** Invoke db:migrate (first_time)
** Invoke environment (first_time)
** Execute environment
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:migrate
** Invoke db:_dump (first_time)
** Execute db:_dump
** Invoke db:schema:dump (first_time)
** Invoke environment 
** Invoke db:load_config 
** Execute db:schema:dump
rake aborted!
ArgumentError: missing keyword: materialized
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic-1.1.1/lib/scenic/view.rb:30:in `initialize'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic_mysql-0.1.2/lib/scenic/adapters/mysql/views.rb:41:in `new'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic_mysql-0.1.2/lib/scenic/adapters/mysql/views.rb:41:in `to_scenic_view'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic_mysql-0.1.2/lib/scenic/adapters/mysql/views.rb:23:in `map'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic_mysql-0.1.2/lib/scenic/adapters/mysql/views.rb:23:in `all'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic_mysql-0.1.2/lib/scenic/adapters/mysql.rb:48:in `views'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic-1.1.1/lib/scenic/schema_dumper.rb:18:in `views_in_database'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic-1.1.1/lib/scenic/schema_dumper.rb:12:in `views'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/scenic-1.1.1/lib/scenic/schema_dumper.rb:8:in `tables'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/schema_dumper.rb:38:in `dump'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/schema_dumper.rb:22:in `dump'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/railties/databases.rake:240:in `block (4 levels) in <top (required)>'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/railties/databases.rake:239:in `open'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/activerecord-4.2.5.1/lib/active_record/railties/databases.rake:239:in `block (3 levels) in <top (required)>'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rake-10.5.0/lib/rake/task.rb:240:in `call'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rake-10.5.0/lib/rake/task.rb:240:in `block in execute'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rake-10.5.0/lib/rake/task.rb:235:in `each'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rake-10.5.0/lib/rake/task.rb:235:in `execute'
/Users/bruno/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rake-10.5.0/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
```

After some inspection it seems the proposed change fixes the issue.