### PR TITLE
Fix bug that prevents use of a explicitly specified database

### DIFF
--- a/lib/scenic/adapters/mysql/tables_definition.rb
+++ b/lib/scenic/adapters/mysql/tables_definition.rb
@@ -10,7 +10,7 @@ module Scenic
           wheres = ["table_type = 'BASE TABLE'"]
 
           if database
-            wheres << "table_schema = #{quote_table_name(database)}"
+            wheres << "table_schema = #{quote(database)}"
           else
             wheres << "table_schema = SCHEMA()"
           end

--- a/scenic_mysql.gemspec
+++ b/scenic_mysql.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "scenic", "~> 1.1.1"
+  spec.add_dependency "scenic", "~> 1.1", ">= 1.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The `quote_table_name` method uses backticks which produce an error. Standard quotes are required in this context.